### PR TITLE
Fix start script cross-platform bug

### DIFF
--- a/start_taskflow.py
+++ b/start_taskflow.py
@@ -3,12 +3,22 @@ import subprocess
 import webbrowser
 import time
 import sys
+import platform
 
 # Define paths
 PROJECT_DIR = os.path.dirname(os.path.abspath(__file__))
 VENV_DIR = os.path.join(PROJECT_DIR, "venv")
 DATABASE_DIR = os.path.join(PROJECT_DIR, "database")
-FASTAPI_CMD = f"{VENV_DIR}/bin/python -m uvicorn backend.main:app --reload"
+
+# Determine the correct Python executable inside the virtual environment
+PYTHON_EXEC = os.path.join(
+    VENV_DIR,
+    "Scripts" if platform.system() == "Windows" else "bin",
+    "python"
+)
+
+# Uvicorn command using the virtual environment's interpreter
+FASTAPI_CMD = f"{PYTHON_EXEC} -m uvicorn backend.main:app --reload"
 TASKFLOW_URL = "http://127.0.0.1:8000/frontend/index.html"
 
 # Ensure the database directory exists
@@ -19,12 +29,22 @@ if not os.path.exists(DATABASE_DIR):
 # Check if the virtual environment exists
 if not os.path.exists(VENV_DIR):
     print("📦 Creating virtual environment...")
-    subprocess.run(["python3", "-m", "venv", "venv"])
+    subprocess.run([sys.executable, "-m", "venv", "venv"], check=True)
     print("✅ Virtual environment created.")
 
 # Ensure dependencies are installed
 print("📦 Checking dependencies...")
-subprocess.run(f"{VENV_DIR}/bin/python -m pip install --upgrade pip fastapi uvicorn sqlalchemy", shell=True, check=True)
+subprocess.run([
+    PYTHON_EXEC,
+    "-m",
+    "pip",
+    "install",
+    "--upgrade",
+    "pip",
+    "fastapi",
+    "uvicorn",
+    "sqlalchemy",
+], check=True)
 
 # Start FastAPI server
 print("🚀 Starting TaskFlow...")
@@ -39,17 +59,28 @@ webbrowser.open(TASKFLOW_URL)
 
 # Function to check if the browser tab is still open
 def is_browser_open():
+    """Check if the TaskFlow tab is still open on macOS.
+
+    On non-macOS platforms this function simply returns ``True`` so the
+    application does not exit unexpectedly.
+    """
+
+    if platform.system() != "Darwin":
+        return True
+
     try:
         output = subprocess.check_output([
-            "osascript", "-e",
+            "osascript",
+            "-e",
             'tell application "Google Chrome" to get the URL of tabs of windows'
         ])
         urls = output.decode().split(", ")
         print(f"🔍 Detected open tabs: {urls}")  # Debugging line
         return TASKFLOW_URL in urls
-    except subprocess.CalledProcessError as e:
+    except (subprocess.CalledProcessError, FileNotFoundError) as e:
         print(f"⚠️ Browser check failed: {e}")  # Debugging line
-        return True  # Keep the program running even if the check fails
+        # Keep the program running even if the check fails
+        return True
 
 # Monitor if the user closes the page
 try:


### PR DESCRIPTION
## Summary
- fix Python executable path construction in `start_taskflow.py`
- ensure dependency install command works on Windows and Unix
- create venv using the current Python executable
- skip `osascript` check on non-macOS platforms

## Testing
- `python3 -m py_compile backend/main.py start_taskflow.py`

------
https://chatgpt.com/codex/tasks/task_e_6840a44a227c8329a4162fda708807e2